### PR TITLE
New pixel based comparisons (and a bug fix)

### DIFF
--- a/ImageSharpCompare/CompareResult.cs
+++ b/ImageSharpCompare/CompareResult.cs
@@ -10,11 +10,15 @@ namespace Codeuctivity
         /// </summary>
         /// <param name="meanError">Mean error</param>
         /// <param name="absoluteError">Absolute error</param>
+        /// <param name="pixelErrorCount">Number of pixels that differ between images</param>
+        /// <param name="pixelErrorPercentage">Percentage of pixels that differ between images</param>
         public CompareResult
-        (int meanError, int absoluteError)
+                (int meanError, int absoluteError, int pixelErrorCount, double pixelErrorPercentage)
         {
             MeanError = meanError;
             AbsoluteError = absoluteError;
+            PixelErrorCount = pixelErrorCount;
+            PixelErrorPercentage = pixelErrorPercentage;
         }
 
         /// <summary>
@@ -27,5 +31,15 @@ namespace Codeuctivity
         /// Absolute pixel error
         /// </summary>
         public int AbsoluteError { get; }
+
+        /// <summary>
+        /// Number of pixels that differ between images
+        /// </summary>
+        public int PixelErrorCount { get; }
+
+        /// <summary>
+        /// Percentage of pixels that differ between images
+        /// </summary>
+        public double PixelErrorPercentage { get; }
     }
 }

--- a/ImageSharpCompare/ICompareResult.cs
+++ b/ImageSharpCompare/ICompareResult.cs
@@ -15,5 +15,15 @@
         /// Absolute pixel error
         /// </summary>
         int AbsoluteError { get; }
+
+        /// <summary>
+        /// Number of pixels that differ between images
+        /// </summary>
+        int PixelErrorCount { get; }
+
+        /// <summary>
+        /// Percentage of pixels that differ between images
+        /// </summary>
+        double PixelErrorPercentage { get; }
     }
 }

--- a/ImageSharpCompare/ImageSharpCompare.cs
+++ b/ImageSharpCompare/ImageSharpCompare.cs
@@ -109,7 +109,7 @@ namespace Codeuctivity
         {
             if (ImagesHaveSameDimension(actual, expected))
             {
-                var quanitiy = actual.Width * actual.Height;
+                var quantity = actual.Width * actual.Height;
                 var absoluteError = 0;
                 var pixelErrorCount = 0;
                 for (var x = 0; x < actual.Width; x++)
@@ -125,8 +125,8 @@ namespace Codeuctivity
                         pixelErrorCount += (r + g + b) > 0 ? 1 : 0;
                     }
                 }
-                var meanError = absoluteError / quanitiy;
-                var pixelErrorPercentage = ((double)pixelErrorCount / quanitiy) * 100;
+                var meanError = absoluteError / quantity;
+                var pixelErrorPercentage = ((double)pixelErrorCount / quantity) * 100;
                 return new CompareResult(absoluteError, meanError, pixelErrorCount, pixelErrorPercentage);
             }
             throw new ImageSharpCompareException(sizeDiffersExceptionMessage);
@@ -148,31 +148,31 @@ namespace Codeuctivity
                     throw new ArgumentNullException(nameof(maskImage));
                 }
 
-                var quanitiy = actual.Width * actual.Height;
+                var quantity = actual.Width * actual.Height;
                 var absoluteError = 0;
                 var pixelErrorCount = 0;
                 for (var x = 0; x < actual.Width; x++)
                 {
                     for (var y = 0; y < actual.Height; y++)
                     {
-                        var maksImagePixel = maskImage[x, y];
+                        var maskImagePixel = maskImage[x, y];
                         var r = Math.Abs(expected[x, y].R - actual[x, y].R);
                         var g = Math.Abs(expected[x, y].G - actual[x, y].G);
                         var b = Math.Abs(expected[x, y].B - actual[x, y].B);
 
                         var error = 0;
 
-                        if (r > maksImagePixel.R)
+                        if (r > maskImagePixel.R)
                         {
                             error += r;
                         }
 
-                        if (g > maksImagePixel.G)
+                        if (g > maskImagePixel.G)
                         {
                             error += g;
                         }
 
-                        if (b > maksImagePixel.B)
+                        if (b > maskImagePixel.B)
                         {
                             error += b;
                         }
@@ -181,8 +181,8 @@ namespace Codeuctivity
                         pixelErrorCount += error > 0 ? 1 : 0;
                     }
                 }
-                var meanError = absoluteError / quanitiy;
-                var pixelErrorPercentage = ((double)pixelErrorCount / quanitiy) * 100;
+                var meanError = absoluteError / quantity;
+                var pixelErrorPercentage = ((double)pixelErrorCount / quantity) * 100;
                 return new CompareResult(absoluteError, meanError, pixelErrorCount, pixelErrorPercentage);
             }
             throw (new ImageSharpCompareException(sizeDiffersExceptionMessage));

--- a/ImageSharpCompare/ImageSharpCompare.cs
+++ b/ImageSharpCompare/ImageSharpCompare.cs
@@ -159,12 +159,12 @@ namespace Codeuctivity
                             absoluteError = absoluteError + r;
                         }
 
-                        if (r > maksImagePixel.G)
+                        if (g > maksImagePixel.G)
                         {
                             absoluteError = absoluteError + g;
                         }
 
-                        if (r > maksImagePixel.B)
+                        if (b > maksImagePixel.B)
                         {
                             absoluteError = absoluteError + b;
                         }

--- a/ImageSharpCompare/ImageSharpCompare.cs
+++ b/ImageSharpCompare/ImageSharpCompare.cs
@@ -111,6 +111,7 @@ namespace Codeuctivity
             {
                 var quanitiy = actual.Width * actual.Height;
                 var absoluteError = 0;
+                var pixelErrorCount = 0;
                 for (var x = 0; x < actual.Width; x++)
                 {
                     for (var y = 0; y < actual.Height; y++)
@@ -120,10 +121,13 @@ namespace Codeuctivity
                         var b = Math.Abs(expected[x, y].B - actual[x, y].B);
 
                         absoluteError = absoluteError + r + g + b;
+
+                        pixelErrorCount += (r + g + b) > 0 ? 1 : 0;
                     }
                 }
                 var meanError = absoluteError / quanitiy;
-                return new CompareResult(absoluteError, meanError);
+                var pixelErrorPercentage = ((double)pixelErrorCount / quanitiy) * 100;
+                return new CompareResult(absoluteError, meanError, pixelErrorCount, pixelErrorPercentage);
             }
             throw new ImageSharpCompareException(sizeDiffersExceptionMessage);
         }
@@ -146,6 +150,7 @@ namespace Codeuctivity
 
                 var quanitiy = actual.Width * actual.Height;
                 var absoluteError = 0;
+                var pixelErrorCount = 0;
                 for (var x = 0; x < actual.Width; x++)
                 {
                     for (var y = 0; y < actual.Height; y++)
@@ -154,24 +159,31 @@ namespace Codeuctivity
                         var r = Math.Abs(expected[x, y].R - actual[x, y].R);
                         var g = Math.Abs(expected[x, y].G - actual[x, y].G);
                         var b = Math.Abs(expected[x, y].B - actual[x, y].B);
+
+                        var error = 0;
+
                         if (r > maksImagePixel.R)
                         {
-                            absoluteError = absoluteError + r;
+                            error += r;
                         }
 
                         if (g > maksImagePixel.G)
                         {
-                            absoluteError = absoluteError + g;
+                            error += g;
                         }
 
                         if (b > maksImagePixel.B)
                         {
-                            absoluteError = absoluteError + b;
+                            error += b;
                         }
+
+                        absoluteError += error;
+                        pixelErrorCount += error > 0 ? 1 : 0;
                     }
                 }
                 var meanError = absoluteError / quanitiy;
-                return new CompareResult(absoluteError, meanError);
+                var pixelErrorPercentage = ((double)pixelErrorCount / quanitiy) * 100;
+                return new CompareResult(absoluteError, meanError, pixelErrorCount, pixelErrorPercentage);
             }
             throw (new ImageSharpCompareException(sizeDiffersExceptionMessage));
         }

--- a/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
+++ b/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
@@ -19,7 +19,7 @@ namespace ImageSharpCompareTestNunit
         [Test]
         [TestCase(jpg0, jpg0)]
         [TestCase(png0, png0)]
-        public void ShouldVerfiyThatImagesAreEqual(string pathActual, string pathExpected)
+        public void ShouldVerifyThatImagesAreEqual(string pathActual, string pathExpected)
         {
             Assert.That(ImageSharpCompare.ImageAreEqual(pathActual, pathExpected), Is.True);
         }
@@ -31,7 +31,7 @@ namespace ImageSharpCompareTestNunit
         [TestCase(jpg1, jpg1, 0, 0, 0, 0)]
         [TestCase(jpg0, jpg1, 208832, 1, 2089, 1.2923461433768035d)]
         [TestCase(png0, png1, 203027, 1, 681, 0.42129618173269651d)]
-        public void ShouldVerfiyThatImagesAreSemiEqual(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage)
+        public void ShouldVerifyThatImagesAreSemiEqual(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage)
         {
             var diff = ImageSharpCompare.CalcDiff(pathPic1, pathPic2);
             Assert.That(diff.AbsoluteError, Is.EqualTo(expectedAbsoluteError), "AbsoluteError");
@@ -62,7 +62,7 @@ namespace ImageSharpCompareTestNunit
         [TestCase(jpg0, png1)]
         [TestCase(jpg0, png0)]
         [TestCase(jpg1, png1)]
-        public void ShouldVerifyThatImagesAreNotEqal(string pathActual, string pathExpected)
+        public void ShouldVerifyThatImagesAreNotEqual(string pathActual, string pathExpected)
         {
             Assert.That(ImageSharpCompare.ImageAreEqual(pathActual, pathExpected), Is.False);
         }

--- a/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
+++ b/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
@@ -25,21 +25,23 @@ namespace ImageSharpCompareTestNunit
         }
 
         [Test]
-        [TestCase(jpg0, png0, 384538, 2)]
-        [TestCase(jpg1, png1, 382669, 2)]
-        [TestCase(png1, png1, 0, 0)]
-        [TestCase(jpg1, jpg1, 0, 0)]
-        [TestCase(jpg0, jpg1, 208832, 1)]
-        [TestCase(png0, png1, 203027, 1)]
-        public void ShouldVerfiyThatImagesAreSemiEqual(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError)
+        [TestCase(jpg0, png0, 384538, 2, 140855, 87.139021553537404d)]
+        [TestCase(jpg1, png1, 382669, 2, 140893, 87.162530004206772d)]
+        [TestCase(png1, png1, 0, 0, 0, 0)]
+        [TestCase(jpg1, jpg1, 0, 0, 0, 0)]
+        [TestCase(jpg0, jpg1, 208832, 1, 2089, 1.2923461433768035d)]
+        [TestCase(png0, png1, 203027, 1, 681, 0.42129618173269651d)]
+        public void ShouldVerfiyThatImagesAreSemiEqual(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage)
         {
             var diff = ImageSharpCompare.CalcDiff(pathPic1, pathPic2);
             Assert.That(diff.AbsoluteError, Is.EqualTo(expectedAbsoluteError), "AbsoluteError");
             Assert.That(diff.MeanError, Is.EqualTo(expectedMeanError), "MeanError");
+            Assert.That(diff.PixelErrorCount, Is.EqualTo(expectedPixelErrorCount), "PixelErrorCount");
+            Assert.That(diff.PixelErrorPercentage, Is.EqualTo(expectedPixelErrorPercentage), "PixelErrorPercentage");
         }
 
-        [TestCase(png0, png1, 0, 0)]
-        public void Diffmask(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError)
+        [TestCase(png0, png1, 0, 0, 0, 0)]
+        public void Diffmask(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage)
         {
             using (var fileStreamDifferenceMask = File.Create("differenceMask.png"))
             using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(pathPic1, pathPic2))
@@ -50,6 +52,8 @@ namespace ImageSharpCompareTestNunit
             var maskedDiff = ImageSharpCompare.CalcDiff(pathPic1, pathPic2, "differenceMask.png");
             Assert.That(maskedDiff.AbsoluteError, Is.EqualTo(expectedAbsoluteError), "AbsoluteError");
             Assert.That(maskedDiff.MeanError, Is.EqualTo(expectedMeanError), "MeanError");
+            Assert.That(maskedDiff.PixelErrorCount, Is.EqualTo(expectedPixelErrorCount), "PixelErrorCount");
+            Assert.That(maskedDiff.PixelErrorPercentage, Is.EqualTo(expectedPixelErrorPercentage), "PixelErrorPercentage");
         }
 
         [Test]


### PR DESCRIPTION
Comparisons to determine the number of pixels that differ between images, both as a count and percentage of the total number of pixels in the image.

Also includes:
- Bug fix in `public static ICompareResult CalcDiff(Image<Rgba32> actual, Image<Rgba32> expected, Image<Rgba32> maskImage)` which used the `red` value for `green` and `blue` comparisons.
- A few typo fixes