### PR TITLE
README - add note about ignoring alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Inspired by the image compare feature "Visual verification API" of [TestApi](htt
 
 ImageSharpCompare focus on os agnostic support and therefore depends on [SixLabors.ImageSharp](https://github.com/SixLabors/ImageSharp).
 
+**NOTE**: for now the comparer will only work with **RGB** components and totally ignores **A**lpha-channell.
+
 ## Example simple show cases
 
 ```csharp


### PR DESCRIPTION
It may be obvious for users who used the `TestApi` that comparer is working only with RGB channels. But for those who just googled for "compare images with ImageSharp" it may be not so obvious. So, I think such a note may help to saves a little time for someone.