### PR TITLE
Improve diff calculation

### DIFF
--- a/ImageSharpCompare/ImageSharpCompare.cs
+++ b/ImageSharpCompare/ImageSharpCompare.cs
@@ -207,7 +207,7 @@ namespace Codeuctivity.ImageSharpCompare
             }
 
             var quantity = actual.Width * actual.Height;
-            var absoluteError = 0;
+            var absoluteError = 0f;
             var pixelErrorCount = 0;
 
             for (var x = 0; x < actual.Width; x++)
@@ -217,18 +217,18 @@ namespace Codeuctivity.ImageSharpCompare
                     var actualPixel = actual[x, y];
                     var expectedPixel = expected[x, y];
 
-                    var r = Math.Abs(expectedPixel.R - actualPixel.R);
-                    var g = Math.Abs(expectedPixel.G - actualPixel.G);
-                    var b = Math.Abs(expectedPixel.B - actualPixel.B);
-                    absoluteError = absoluteError + r + g + b;
+                    var r = Math.Abs(expectedPixel.R - actualPixel.R) / 255f;
+                    var g = Math.Abs(expectedPixel.G - actualPixel.G) / 255f;
+                    var b = Math.Abs(expectedPixel.B - actualPixel.B) / 255f;
+                    absoluteError += r + g + b;
 
                     pixelErrorCount += r + g + b > 0 ? 1 : 0;
                 }
             }
 
-            var meanError = (double)absoluteError / quantity;
+            var meanError = (double)absoluteError / quantity / 3;
             var pixelErrorPercentage = (double)pixelErrorCount / quantity * 100;
-            return new CompareResult(absoluteError, meanError, pixelErrorCount, pixelErrorPercentage);
+            return new CompareResult((int)absoluteError, meanError, pixelErrorCount, pixelErrorPercentage);
         }
 
         /// <summary>


### PR DESCRIPTION
The diffing logic used in `ICompareResult CalcDiff(Image<Rgb24> actual, Image<Rgb24> expected)` does not report expected results.

For instance, if you create two simple (50x50) box images: one totally filled with black pixels, the other 50% black 50% white, the mean error reported by the original implementation is ~400.
This seems incorrect, the expected mean error is ~0.5.
The RGB values that are being subtracted from one another range from 0->255. The per-channel diff should hence be divided by it.

In addition, the mean should consider that 3 values are being added to the absolute per pixel and not just one. Adding 3 values per pixel yet dividing by total pixel count inflates the error 3x.

Please note that I currently do not have the time to visit the other methods and apply the same logic there. 
It may or may not be applicable to do that.

My goal was to fix the diff per my needs and provide it to you as a suggestion in case you find it useful.