### PR TITLE
Add support for all SixLabors.ImageSharp.PixelFormats

### DIFF
--- a/ImageSharpCompare/ImageSharpCompare.cs
+++ b/ImageSharpCompare/ImageSharpCompare.cs
@@ -350,7 +350,7 @@ namespace Codeuctivity.ImageSharpCompare
                     var g = Math.Abs(expectedPixel.G - actualPixel.G);
                     var b = Math.Abs(expectedPixel.B - actualPixel.B);
                     var sum = r + g + b;
-                    absoluteError = absoluteError + (sum > pixelColorShiftTolerance ? sum : 0);
+                    absoluteError += (sum > pixelColorShiftTolerance ? sum : 0);
                     pixelErrorCount += (sum > pixelColorShiftTolerance) ? 1 : 0;
                 }
             }
@@ -477,7 +477,7 @@ namespace Codeuctivity.ImageSharpCompare
                         error += b;
                     }
 
-                    absoluteError = absoluteError + (error > pixelColorShiftTolerance ? error : 0);
+                    absoluteError += (error > pixelColorShiftTolerance ? error : 0);
                     pixelErrorCount += error > pixelColorShiftTolerance ? 1 : 0;
                 }
             }
@@ -752,19 +752,17 @@ namespace Codeuctivity.ImageSharpCompare
                 return actualPixelAccessibleImage;
             }
 
-            if (actual is Image<Rgba32> imageRgba32)
-            {
-                ownsImage = true;
-                return ConvertRgba32ToRgb24(imageRgba32);
-            }
-
-            throw new NotImplementedException($"Pixel type {actual.PixelType} is not supported to be compared.");
+            ownsImage = true;
+            return actual.CloneAs<Rgb24>();
         }
 
         /// <summary>
         /// Converts a Rgba32 Image to Rgb24 one
         /// </summary>
         /// <param name="imageRgba32"></param>
+#pragma warning disable S1133 // Give the consumer of the public method some time to migrate
+        [Obsolete("use 'imageRgba32..CloneAs<Rgb24>()' instead")]
+#pragma warning restore S1133 
         public static Image<Rgb24> ConvertRgba32ToRgb24(Image<Rgba32> imageRgba32)
         {
             ArgumentNullException.ThrowIfNull(imageRgba32);

--- a/ImageSharpCompare/ImageSharpCompare.cs
+++ b/ImageSharpCompare/ImageSharpCompare.cs
@@ -139,8 +139,8 @@ namespace Codeuctivity.ImageSharpCompare
             Image<Rgb24>? expectedPixelAccusableImage = null;
             try
             {
-                actualPixelAccessibleImage = ToRgb24Image(actual, out ownsActual);
-                expectedPixelAccusableImage = ToRgb24Image(expected, out ownsExpected);
+                actualPixelAccessibleImage = ImageSharpPixelTypeConverter.ToRgb24Image(actual, out ownsActual);
+                expectedPixelAccusableImage = ImageSharpPixelTypeConverter.ToRgb24Image(expected, out ownsExpected);
 
                 return ImagesAreEqual(actualPixelAccessibleImage, expectedPixelAccusableImage, resizeOption);
             }
@@ -286,8 +286,8 @@ namespace Codeuctivity.ImageSharpCompare
 
             try
             {
-                actualRgb24 = ToRgb24Image(actual, out ownsActual);
-                expectedRgb24 = ToRgb24Image(expected, out ownsExpected);
+                actualRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(actual, out ownsActual);
+                expectedRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(expected, out ownsExpected);
 
                 return CalcDiff(actualRgb24, expectedRgb24, resizeOption, pixelColorShiftTolerance);
             }
@@ -386,9 +386,9 @@ namespace Codeuctivity.ImageSharpCompare
 
             try
             {
-                actualRgb24 = ToRgb24Image(actual, out ownsActual);
-                expectedRgb24 = ToRgb24Image(expected, out ownsExpected);
-                maskImageRgb24 = ToRgb24Image(maskImage, out ownsMask);
+                actualRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(actual, out ownsActual);
+                expectedRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(expected, out ownsExpected);
+                maskImageRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(maskImage, out ownsMask);
 
                 return CalcDiff(actualRgb24, expectedRgb24, maskImageRgb24, resizeOption, pixelColorShiftTolerance);
             }
@@ -571,8 +571,8 @@ namespace Codeuctivity.ImageSharpCompare
 
             try
             {
-                actualRgb24 = ToRgb24Image(actual, out ownsActual);
-                expectedRgb24 = ToRgb24Image(expected, out ownsExpected);
+                actualRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(actual, out ownsActual);
+                expectedRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(expected, out ownsExpected);
 
                 return CalcDiffMaskImage(actualRgb24, expectedRgb24, resizeOption, pixelColorShiftTolerance);
             }
@@ -612,9 +612,9 @@ namespace Codeuctivity.ImageSharpCompare
 
             try
             {
-                actualRgb24 = ToRgb24Image(actual, out ownsActual);
-                expectedRgb24 = ToRgb24Image(expected, out ownsExpected);
-                maskRgb24 = ToRgb24Image(mask, out ownsMask);
+                actualRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(actual, out ownsActual);
+                expectedRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(expected, out ownsExpected);
+                maskRgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(mask, out ownsMask);
 
                 return CalcDiffMaskImage(actualRgb24, expectedRgb24, maskRgb24, resizeOption, pixelColorShiftTolerance);
             }
@@ -742,18 +742,6 @@ namespace Codeuctivity.ImageSharpCompare
                 grown.Item2?.Dispose();
                 grown.Item3?.Dispose();
             }
-        }
-
-        private static Image<Rgb24> ToRgb24Image(Image actual, out bool ownsImage)
-        {
-            if (actual is Image<Rgb24> actualPixelAccessibleImage)
-            {
-                ownsImage = false;
-                return actualPixelAccessibleImage;
-            }
-
-            ownsImage = true;
-            return actual.CloneAs<Rgb24>();
         }
 
         /// <summary>

--- a/ImageSharpCompare/ImageSharpCompare.csproj
+++ b/ImageSharpCompare/ImageSharpCompare.csproj
@@ -46,7 +46,7 @@
 	<ItemGroup>
 		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.18.0.83559">
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.24.0.89429">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ImageSharpCompare/ImageSharpPixelTypeConverter.cs
+++ b/ImageSharpCompare/ImageSharpPixelTypeConverter.cs
@@ -1,0 +1,31 @@
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using System;
+
+namespace Codeuctivity.ImageSharpCompare
+{
+    /// <summary>
+    /// Provides functionality to convert an ImageSharp image of any pixel type to an ImageSharp image with Rgb24 pixel type.
+    /// </summary>
+    public static class ImageSharpPixelTypeConverter
+    {
+        /// <summary>
+        /// Converts an Image with any pixel type to Rgb24
+        /// </summary>
+        /// <param name="image"></param>
+        /// <param name="isClonedInstance">Use this to dispose cloned instances</param>
+        public static Image<Rgb24> ToRgb24Image(Image image, out bool isClonedInstance)
+        {
+            ArgumentNullException.ThrowIfNull(image);
+
+            if (image is Image<Rgb24> actualPixelAccessibleImage)
+            {
+                isClonedInstance = false;
+                return actualPixelAccessibleImage;
+            }
+
+            isClonedInstance = true;
+            return image.CloneAs<Rgb24>();
+        }
+    }
+}

--- a/ImageSharpCompareTestNunit/AssertDisposeBehavior.cs
+++ b/ImageSharpCompareTestNunit/AssertDisposeBehavior.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using SixLabors.ImageSharp;
+using System;
+using System.Reflection;
+
+namespace ImageSharpCompareTestNunit
+{
+    internal static class AssertDisposeBehavior
+    {
+
+        internal static void AssertThatImageIsDisposed(Image image, bool expectedDisposeState = false)
+        {
+            const string imageSharpPrivateFieldNameIsDisposed = "isDisposed";
+            var isDisposed = (bool?)GetInstanceField(image, imageSharpPrivateFieldNameIsDisposed);
+            Assert.That(isDisposed, Is.EqualTo(expectedDisposeState));
+            image.Dispose();
+            isDisposed = (bool?)GetInstanceField(image, imageSharpPrivateFieldNameIsDisposed);
+            Assert.That(isDisposed, Is.True);
+        }
+
+        private static object? GetInstanceField<T>(T instance, string fieldName)
+        {
+            var bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+            var field = typeof(T).GetField(fieldName, bindFlags);
+            return field == null ? throw new ArgumentNullException(fieldName) : field.GetValue(instance);
+        }
+    }
+}

--- a/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
+++ b/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
@@ -296,13 +296,13 @@ namespace ImageSharpCompareTestNunit
         [TestCase(jpg0Rgb24, jpg1Rgb24, 0, 0, 0, 0, ResizeOption.DontResize)]
         [TestCase(jpg0Rgb24, jpg1Rgb24, 0, 0, 0, 0, ResizeOption.Resize)]
         [TestCase(pngBlack2x2px, pngBlack4x4px, 0, 0, 0, 0, ResizeOption.Resize)]
-        public void ShouldCalcDiffMaskImageHalfSingleSharpAndUseOutcome(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage, ResizeOption resizeOption)
+        public void ShouldCalcDiffMaskImageHalfSingleHalfVector2AndUseOutcome(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage, ResizeOption resizeOption)
         {
             var absolutePathPic1 = Path.Combine(AppContext.BaseDirectory, pathPic1);
             var absolutePathPic2 = Path.Combine(AppContext.BaseDirectory, pathPic2);
             var differenceMaskPicPath = Path.GetTempFileName() + "differenceMask.png";
 
-            using var absolutePic1 = Image.Load(absolutePathPic1);
+            using var absolutePic1 = Image.Load<HalfVector2>(absolutePathPic1);
             using var absolutePic2 = Image.Load(absolutePathPic2);
 
             using (var fileStreamDifferenceMask = File.Create(differenceMaskPicPath))

--- a/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
+++ b/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
@@ -4,7 +4,6 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.IO;
-using System.Reflection;
 
 namespace ImageSharpCompareTestNunit
 {
@@ -121,8 +120,8 @@ namespace ImageSharpCompareTestNunit
             using var expected = Image.Load(absolutePathExpected);
 
             Assert.That(ImageSharpCompare.ImagesAreEqual(actual, expected), Is.True);
-            AssertDisposeBehavior(actual);
-            AssertDisposeBehavior(expected);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(actual);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(expected);
         }
 
         [Test]
@@ -137,8 +136,8 @@ namespace ImageSharpCompareTestNunit
             using var expected = Image.Load<Bgra32>(absolutePathExpected);
 
             Assert.That(ImageSharpCompare.ImagesAreEqual(actual, expected), Is.True);
-            AssertDisposeBehavior(actual);
-            AssertDisposeBehavior(expected);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(actual);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(expected);
         }
 
         [Test]
@@ -153,8 +152,8 @@ namespace ImageSharpCompareTestNunit
             using var expected = Image.Load<Bgra5551>(absolutePathExpected);
 
             Assert.That(ImageSharpCompare.ImagesAreEqual(actual, expected), Is.True);
-            AssertDisposeBehavior(actual);
-            AssertDisposeBehavior(expected);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(actual);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(expected);
         }
 
         [Test]
@@ -286,10 +285,10 @@ namespace ImageSharpCompareTestNunit
             Assert.That(maskedDiff.MeanError, Is.EqualTo(expectedMeanError), "MeanError");
             Assert.That(maskedDiff.PixelErrorCount, Is.EqualTo(expectedPixelErrorCount), "PixelErrorCount");
             Assert.That(maskedDiff.PixelErrorPercentage, Is.EqualTo(expectedPixelErrorPercentage), "PixelErrorPercentage");
-
-            AssertDisposeBehavior(absolutePic1);
-            AssertDisposeBehavior(absolutePic2);
-            AssertDisposeBehavior(differenceMaskPic);
+            AssertDisposeBehavior.
+                        AssertThatImageIsDisposed(absolutePic1);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(absolutePic2);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(differenceMaskPic);
         }
 
         [TestCase(png0Rgba32, png1Rgba32, 0, 0, 0, 0, ResizeOption.DontResize)]
@@ -319,10 +318,10 @@ namespace ImageSharpCompareTestNunit
             Assert.That(maskedDiff.MeanError, Is.EqualTo(expectedMeanError), "MeanError");
             Assert.That(maskedDiff.PixelErrorCount, Is.EqualTo(expectedPixelErrorCount), "PixelErrorCount");
             Assert.That(maskedDiff.PixelErrorPercentage, Is.EqualTo(expectedPixelErrorPercentage), "PixelErrorPercentage");
-
-            AssertDisposeBehavior(absolutePic1);
-            AssertDisposeBehavior(absolutePic2);
-            AssertDisposeBehavior(differenceMaskPic);
+            AssertDisposeBehavior.
+                        AssertThatImageIsDisposed(absolutePic1);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(absolutePic2);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(differenceMaskPic);
         }
 
         [TestCase(pngWhite2x2px, pngBlack2x2px, pngTransparent2x2px, 765, 12240, 16, 100d, ResizeOption.Resize, 0)]
@@ -346,10 +345,10 @@ namespace ImageSharpCompareTestNunit
             Assert.That(maskedDiff.AbsoluteError, Is.EqualTo(expectedAbsoluteError), "AbsoluteError");
             Assert.That(maskedDiff.PixelErrorCount, Is.EqualTo(expectedPixelErrorCount), "PixelErrorCount");
             Assert.That(maskedDiff.PixelErrorPercentage, Is.EqualTo(expectedPixelErrorPercentage), "PixelErrorPercentage");
-
-            AssertDisposeBehavior(pic1);
-            AssertDisposeBehavior(pic2);
-            AssertDisposeBehavior(maskPic);
+            AssertDisposeBehavior.
+                        AssertThatImageIsDisposed(pic1);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(pic2);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(maskPic);
         }
 
         [TestCase(pngBlack2x2px, pngBlack2x2px, pngBlack4x4px)]
@@ -367,28 +366,13 @@ namespace ImageSharpCompareTestNunit
             var exception = Assert.Throws<ImageSharpCompareException>(() => ImageSharpCompare.CalcDiff(pic1, pic2, maskPic, ResizeOption.DontResize));
 
             Assert.That(exception?.Message, Is.EqualTo("Size of images differ."));
-
-            AssertDisposeBehavior(pic1);
-            AssertDisposeBehavior(pic2);
-            AssertDisposeBehavior(maskPic);
+            AssertDisposeBehavior.
+                        AssertThatImageIsDisposed(pic1);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(pic2);
+            AssertDisposeBehavior.AssertThatImageIsDisposed(maskPic);
         }
 
-        private static void AssertDisposeBehavior(Image image)
-        {
-            const string imageSharpPrivateFieldNameIsDisposed = "isDisposed";
-            var isDisposed = (bool?)GetInstanceField(image, imageSharpPrivateFieldNameIsDisposed);
-            Assert.That(isDisposed, Is.False);
-            image.Dispose();
-            isDisposed = (bool?)GetInstanceField(image, imageSharpPrivateFieldNameIsDisposed);
-            Assert.That(isDisposed, Is.True);
-        }
 
-        private static object? GetInstanceField<T>(T instance, string fieldName)
-        {
-            var bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
-            var field = typeof(T).GetField(fieldName, bindFlags);
-            return field == null ? throw new ArgumentNullException(fieldName) : field.GetValue(instance);
-        }
 
         [TestCase(png0Rgba32, png1Rgba32, 0, 0, 0, 0)]
         public void DiffMaskSteams(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage)

--- a/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
+++ b/ImageSharpCompareTestNunit/ImageSharpCompareTest.cs
@@ -126,6 +126,38 @@ namespace ImageSharpCompareTestNunit
         }
 
         [Test]
+        [TestCase(jpg0Rgb24, jpg0Rgb24)]
+        [TestCase(png0Rgba32, png0Rgba32)]
+        public void ShouldVerifyThatImageSharpImagesAreEqualBrga(string pathActual, string pathExpected)
+        {
+            var absolutePathActual = Path.Combine(AppContext.BaseDirectory, pathActual);
+            var absolutePathExpected = Path.Combine(AppContext.BaseDirectory, pathExpected);
+
+            using var actual = Image.Load(absolutePathActual);
+            using var expected = Image.Load<Bgra32>(absolutePathExpected);
+
+            Assert.That(ImageSharpCompare.ImagesAreEqual(actual, expected), Is.True);
+            AssertDisposeBehavior(actual);
+            AssertDisposeBehavior(expected);
+        }
+
+        [Test]
+        [TestCase(jpg0Rgb24, jpg0Rgb24)]
+        [TestCase(png0Rgba32, png0Rgba32)]
+        public void ShouldVerifyThatImageSharpImagesAreEqualBgra5551(string pathActual, string pathExpected)
+        {
+            var absolutePathActual = Path.Combine(AppContext.BaseDirectory, pathActual);
+            var absolutePathExpected = Path.Combine(AppContext.BaseDirectory, pathExpected);
+
+            using var actual = Image.Load<Bgra5551>(absolutePathActual);
+            using var expected = Image.Load<Bgra5551>(absolutePathExpected);
+
+            Assert.That(ImageSharpCompare.ImagesAreEqual(actual, expected), Is.True);
+            AssertDisposeBehavior(actual);
+            AssertDisposeBehavior(expected);
+        }
+
+        [Test]
         [TestCase(jpg0Rgb24, png0Rgba32, 384538, 2.3789191061839596d, 140855, 87.139021553537404d, null, 0)]
         [TestCase(jpg0Rgb24, png0Rgba32, 384538, 2.3789191061839596d, 140855, 87.139021553537404d, ResizeOption.DontResize, 0)]
         [TestCase(jpg0Rgb24, png0Rgba32, 384538, 2.3789191061839596d, 140855, 87.139021553537404d, ResizeOption.Resize, 0)]
@@ -232,6 +264,39 @@ namespace ImageSharpCompareTestNunit
         [TestCase(jpg0Rgb24, jpg1Rgb24, 0, 0, 0, 0, ResizeOption.Resize)]
         [TestCase(pngBlack2x2px, pngBlack4x4px, 0, 0, 0, 0, ResizeOption.Resize)]
         public void ShouldCalcDiffMaskImageSharpAndUseOutcome(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage, ResizeOption resizeOption)
+        {
+            var absolutePathPic1 = Path.Combine(AppContext.BaseDirectory, pathPic1);
+            var absolutePathPic2 = Path.Combine(AppContext.BaseDirectory, pathPic2);
+            var differenceMaskPicPath = Path.GetTempFileName() + "differenceMask.png";
+
+            using var absolutePic1 = Image.Load(absolutePathPic1);
+            using var absolutePic2 = Image.Load(absolutePathPic2);
+
+            using (var fileStreamDifferenceMask = File.Create(differenceMaskPicPath))
+            using (var maskImage = ImageSharpCompare.CalcDiffMaskImage(absolutePic1, absolutePic2, resizeOption))
+            {
+                ImageExtensions.SaveAsPng(maskImage, fileStreamDifferenceMask);
+            }
+
+            using var differenceMaskPic = Image.Load(differenceMaskPicPath);
+            var maskedDiff = ImageSharpCompare.CalcDiff(absolutePic1, absolutePic2, differenceMaskPic, resizeOption);
+            File.Delete(differenceMaskPicPath);
+
+            Assert.That(maskedDiff.AbsoluteError, Is.EqualTo(expectedAbsoluteError), "AbsoluteError");
+            Assert.That(maskedDiff.MeanError, Is.EqualTo(expectedMeanError), "MeanError");
+            Assert.That(maskedDiff.PixelErrorCount, Is.EqualTo(expectedPixelErrorCount), "PixelErrorCount");
+            Assert.That(maskedDiff.PixelErrorPercentage, Is.EqualTo(expectedPixelErrorPercentage), "PixelErrorPercentage");
+
+            AssertDisposeBehavior(absolutePic1);
+            AssertDisposeBehavior(absolutePic2);
+            AssertDisposeBehavior(differenceMaskPic);
+        }
+
+        [TestCase(png0Rgba32, png1Rgba32, 0, 0, 0, 0, ResizeOption.DontResize)]
+        [TestCase(jpg0Rgb24, jpg1Rgb24, 0, 0, 0, 0, ResizeOption.DontResize)]
+        [TestCase(jpg0Rgb24, jpg1Rgb24, 0, 0, 0, 0, ResizeOption.Resize)]
+        [TestCase(pngBlack2x2px, pngBlack4x4px, 0, 0, 0, 0, ResizeOption.Resize)]
+        public void ShouldCalcDiffMaskImageHalfSingleSharpAndUseOutcome(string pathPic1, string pathPic2, int expectedMeanError, int expectedAbsoluteError, int expectedPixelErrorCount, double expectedPixelErrorPercentage, ResizeOption resizeOption)
         {
             var absolutePathPic1 = Path.Combine(AppContext.BaseDirectory, pathPic1);
             var absolutePathPic2 = Path.Combine(AppContext.BaseDirectory, pathPic2);

--- a/ImageSharpCompareTestNunit/ImageSharpCompareTestNunit.csproj
+++ b/ImageSharpCompareTestNunit/ImageSharpCompareTestNunit.csproj
@@ -8,12 +8,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="nunit" Version="4.0.1" />
-		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.18.0.83559">
+		<PackageReference Include="nunit" Version="4.1.0" />
+		<PackageReference Include="SonarAnalyzer.CSharp" Version="9.24.0.89429">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
@@ -21,7 +21,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ImageSharpCompareTestNunit/ImageSharpPixelTypeConverterTests.cs
+++ b/ImageSharpCompareTestNunit/ImageSharpPixelTypeConverterTests.cs
@@ -1,0 +1,46 @@
+﻿using Codeuctivity.ImageSharpCompare;
+using NUnit.Framework;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.IO;
+
+namespace ImageSharpCompareTestNunit
+{
+    public class ImageSharpPixelTypeConverterTests
+    {
+        private const string pngBlack2x2px = "../../../TestData/Black.png";
+
+        [Test]
+        public void ShouldConvertToRgb24()
+        {
+            var absolutePathActual = Path.Combine(AppContext.BaseDirectory, pngBlack2x2px);
+
+            var image = Image.Load<Rgb24>(absolutePathActual);
+
+            var rgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(image, out var isClonedInstance);
+
+            Assert.That(isClonedInstance, Is.False);
+            Assert.That(rgb24.PixelType.BitsPerPixel, Is.EqualTo(24));
+
+            image.Dispose();
+            AssertDisposeBehavior.AssertThatImageIsDisposed(rgb24, true);
+        }
+
+        [Test]
+        public void ShouldConvertAnyPixelTypeToRgb24()
+        {
+            var absolutePathActual = Path.Combine(AppContext.BaseDirectory, pngBlack2x2px);
+
+            var image = Image.Load<Rgba64>(absolutePathActual);
+
+            var rgb24 = ImageSharpPixelTypeConverter.ToRgb24Image(image, out var isClonedInstance);
+
+            Assert.That(isClonedInstance, Is.True);
+            Assert.That(rgb24.PixelType.BitsPerPixel, Is.EqualTo(24));
+
+            image.Dispose();
+            AssertDisposeBehavior.AssertThatImageIsDisposed(rgb24);
+        }
+    }
+}


### PR DESCRIPTION
Marked ConvertRgba32ToRgb24 obsolete